### PR TITLE
new Iteration output wrapper

### DIFF
--- a/samples/GaAs_long/felix.inp
+++ b/samples/GaAs_long/felix.inp
@@ -4,7 +4,7 @@
 # ------------------------------------
 
 # control flags
-IWriteFLAG                = 2
+IWriteFLAG                = 1
 IImageFLAG                = 1
 IScatterFactorMethodFLAG  = 0
 IMaskFLAG                 = 1

--- a/samples/GaAs_short/felix.inp
+++ b/samples/GaAs_short/felix.inp
@@ -4,7 +4,7 @@
 # ------------------------------------
 
 # control flags
-IWriteFLAG                = 2
+IWriteFLAG                = 1
 IImageFLAG                = 1
 IScatterFactorMethodFLAG  = 0
 IMaskFLAG                 = 1

--- a/samples/SrTiO3_long/felix.inp
+++ b/samples/SrTiO3_long/felix.inp
@@ -4,7 +4,7 @@
 # ------------------------------------
 
 # control flags
-IWriteFLAG                = 2
+IWriteFLAG                = 1
 IImageFLAG                = 1
 IScatterFactorMethodFLAG  = 0
 IMaskFLAG                 = 1

--- a/src/felix/felixrefine.f90
+++ b/src/felix/felixrefine.f90
@@ -950,7 +950,7 @@ CONTAINS
       CALL message(LS,no_tag,"Simplex ",ind, " of ", INoOfVariables+1)
       CALL message(LS,"--------------------------------")
       CALL SimulateAndFit(RSimplexVariable(ind,:),Iter,IThicknessIndex,IErr)! Working as iteration 0?
-      IF(l_alert(IErr,"SimplexRefinement","doing initial SimulateAndFit")) RETURN
+      IF(l_alert(IErr,"SimplexRefinement","SimulateAndFit")) RETURN
 
       RSimplexFoM(ind)=RFigureofMerit ! RFigureofMerit returned as global variable
       ! For masked correlation, add to 'average' (extreme difference from baseline)?
@@ -1260,6 +1260,7 @@ CONTAINS
     CALL SimulateAndFit(RIndependentVariable,Iter,IThicknessIndex,IErr)
     IF(l_alert(IErr,"MaxGradientRefinement","SimulateAndFit")) RETURN
     CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+    IF(l_alert(IErr,"MaxGradientRefinement","WriteIterationOutputWrapper")) RETURN
     DEALLOCATE(RVar0,RCurrentVar,RLastVar,RPVec,RFitVec,STAT=IErr)  
 
   END SUBROUTINE MaxGradientRefinement
@@ -1400,6 +1401,7 @@ CONTAINS
           CALL SimulateAndFit(RCurrentVar,Iter,IThicknessIndex,IErr)
           IF(l_alert(IErr,"ParabolicRefinement","SimulateAndFit")) RETURN
           CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+          IF(l_alert(IErr,"ParabolicRefinement","WriteIterationOutputWrapper")) RETURN
           ! update RIndependentVariable if necessary
           CALL BestFitCheck(RFigureofMerit,RBestFit,RCurrentVar,RIndependentVariable,IErr)
         END IF
@@ -1423,6 +1425,7 @@ CONTAINS
         CALL SimulateAndFit(RCurrentVar,Iter,IThicknessIndex,IErr)
         IF(l_alert(IErr,"ParabolicRefinement","SimulateAndFit")) RETURN
         CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+        IF(l_alert(IErr,"ParabolicRefinement","WriteIterationOutputWrapper")) RETURN
         CALL BestFitCheck(RFigureofMerit,RBestFit,RCurrentVar,RIndependentVariable,IErr)
         R3fit(2)=RFigureofMerit
         !CALL message ( LM, "point 2",R3var(2) )
@@ -1442,6 +1445,7 @@ CONTAINS
         CALL SimulateAndFit(RCurrentVar,Iter,IThicknessIndex,IErr)
         IF(l_alert(IErr,"ParabolicRefinement","SimulateAndFit")) RETURN
         CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+        IF(l_alert(IErr,"ParabolicRefinement","WriteIterationOutputWrapper")) RETURN
         CALL BestFitCheck(RFigureofMerit,RBestFit,RCurrentVar,RIndependentVariable,IErr)
         R3fit(3)=RFigureofMerit
         !CALL message ( LM, "point 3",R3var(3) )
@@ -1492,6 +1496,7 @@ CONTAINS
           CALL SimulateAndFit(RCurrentVar,Iter,IThicknessIndex,IErr)
           IF(l_alert(IErr,"ParabolicRefinement","SimulateAndFit")) RETURN
           CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+          IF(l_alert(IErr,"ParabolicRefinement","WriteIterationOutputWrapper")) RETURN
           CALL BestFitCheck(RFigureofMerit,RBestFit,RCurrentVar,RIndependentVariable,IErr)
           R3fit(lnd)=RFigureofMerit
           jnd=MAXLOC(R3var,1) ! highest x
@@ -1512,7 +1517,8 @@ CONTAINS
           Iter=Iter+1
           CALL SimulateAndFit(RCurrentVar,Iter,IThicknessIndex,IErr)
           IF(l_alert(IErr,"ParabolicRefinement","SimulateAndFit")) RETURN
-          CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr) 
+          CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+          IF(l_alert(IErr,"ParabolicRefinement","WriteIterationOutputWrapper")) RETURN
           CALL BestFitCheck(RFigureofMerit,RBestFit,RCurrentVar,RIndependentVariable,IErr)
         ELSE
           CALL Parabo3(R3var,R3fit,RvarMin,RfitMin,IErr)
@@ -1529,6 +1535,7 @@ CONTAINS
           CALL SimulateAndFit(RCurrentVar,Iter,IThicknessIndex,IErr)
           IF(l_alert(IErr,"ParabolicRefinement","SimulateAndFit")) RETURN
           CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+          IF(l_alert(IErr,"ParabolicRefinement","WriteIterationOutputWrapper")) RETURN
           CALL BestFitCheck(RFigureofMerit,RBestFit,RCurrentVar,RIndependentVariable,IErr)
         END IF
 
@@ -1580,6 +1587,7 @@ CONTAINS
     CALL SimulateAndFit(RIndependentVariable,Iter,IThicknessIndex,IErr)
     IF(l_alert(IErr,"ParabolicRefinement","SimulateAndFit")) RETURN
     CALL WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+    IF(l_alert(IErr,"ParabolicRefinement","WriteIterationOutputWrapper")) RETURN
     DEALLOCATE(RVar0,RCurrentVar,RLastVar,RPVec,STAT=IErr)
  
   END SUBROUTINE ParabolicRefinement

--- a/src/felix/felixrefine.f90
+++ b/src/felix/felixrefine.f90
@@ -791,6 +791,7 @@ PROGRAM Felixrefine
         RImageBase=RImageSimi  
         RImageAvi=RImageSimi 
       END IF
+      CALL message ( LS, "Writing output; baseline simulation" )
       CALL WriteIterationOutput(Iter,IThicknessIndex,IExitFLAG,IErr)
       IF(l_alert(IErr,"felixrefine","WriteIterationOutput")) CALL abort
       

--- a/src/felix/refinementcontrol_mod.f90
+++ b/src/felix/refinementcontrol_mod.f90
@@ -73,7 +73,7 @@ MODULE refinementcontrol_mod
 
     ! global inputs
     USE IPARA, ONLY : INoOfVariables, nReflections, IAbsorbFLAG, IMethodFLAG, INoofUgs, &
-          IPixelCount, IPrint, ISimFLAG, ISymmetryRelations, IUgOffset, IRefineMode, &
+          IPixelCount, ISimFLAG, ISymmetryRelations, IUgOffset, IRefineMode, &
           IEquivalentUgKey
     USE RPARA, ONLY : RAngstromConversion,RElectronCharge,RElectronMass,&
           RConvergenceAngle, RMinimumGMag, RTolerance, RRelativisticCorrection, &

--- a/src/felix/refinementcontrol_mod.f90
+++ b/src/felix/refinementcontrol_mod.f90
@@ -81,7 +81,6 @@ MODULE refinementcontrol_mod
     USE RConst, ONLY : RPlanckConstant
 
     ! gloabl outputs
-    USE IPARA, ONLY : IPreviousPrintedIteration 
     USE CPARA, ONLY : CUgMatNoAbs, CUniqueUg
     USE RPARA, ONLY : RAbsorptionPercentage, RDeltaK, RFigureofMerit, RSimulatedPatterns
 

--- a/src/felix/simplex_mod.f90
+++ b/src/felix/simplex_mod.f90
@@ -71,8 +71,7 @@ MODULE simplex_mod
           swap, ysave, Rytry, psum(ndim), amotry, RStandardDeviation, RStandardError, &
           RStandardTolerance
     PARAMETER (NMAX=1000,ITMAX=50000)
-    INTEGER(IKIND) :: i, ihi, ilo, inhi, j, m, n, IExitFlag, IThicknessIndex, &
-          IPreviousPrintedIteration
+    INTEGER(IKIND) :: i, ihi, ilo, inhi, j, m, n, IExitFlag, IThicknessIndex
     
     Rytry=ZERO ! initial value, has no significance
 

--- a/src/felix/write_output_mod.f90
+++ b/src/felix/write_output_mod.f90
@@ -54,11 +54,22 @@ MODULE write_output_mod
     INTEGER(IKIND),INTENT(IN) :: Iter,IThicknessIndex,IExitFLAG
     INTEGER(IKIND),INTENT(OUT) :: IErr
 
+    IF(Iter.EQ.0) IErr=1
+    IF(l_alert(IErr,"WriteIterationOutputWrapper","Unexpectedly recieved Iter = 0")) RETURN
+
+
     IF(my_rank.EQ.0) THEN
       ! use IPrint from felix.inp to specify how often to write Iteration output
       IF(IExitFLAG.EQ.1.OR.(Iter.GE.(IPreviousPrintedIteration+IPrint))) THEN
+        IF(IExitFLAG.EQ.0) THEN
+          CALL message ( LS, "Writing output; iterations since the previous save = ", &
+                Iter-IPreviousPrintedIteration)
+        ELSE
+          CALL message ( LS, "Writing output; final simulation" )
+        END IF
         CALL WriteIterationOutput(Iter,IThicknessIndex,IExitFLAG,IErr)
         IF(l_alert(IErr,"WriteIterationOutputWrapper","WriteIterationOutput")) RETURN
+        IPreviousPrintedIteration = Iter 
       END IF
     END IF
 
@@ -103,15 +114,6 @@ MODULE write_output_mod
             "Sim_",IThickness,"nm_",2*IPixelcount,"x",2*IPixelcount
     END IF
     CALL system('mkdir ' // path)
-
-    IF (ISimFLAG.EQ.0.AND.IExitFLAG.EQ.0) THEN ! felixrefine output
-      IF (Iter.EQ.0) THEN
-        CALL message ( LS, "Writing output; baseline simulation" )
-      ELSE
-        CALL message ( LS, "Writing output; iterations since the previous save = ", &
-              Iter-IPreviousPrintedIteration)
-      END IF
-    END IF
     
     ! Write Images to disk
     DO ind = 1,INoOfLacbedPatterns
@@ -149,8 +151,6 @@ MODULE write_output_mod
     END DO
 
     CLOSE(IChOut)    
-
-    IPreviousPrintedIteration = Iter 
     
     RETURN  
     

--- a/src/felix/write_output_mod.f90
+++ b/src/felix/write_output_mod.f90
@@ -59,7 +59,6 @@ MODULE write_output_mod
       IF(IExitFLAG.EQ.1.OR.(Iter.GE.(IPreviousPrintedIteration+IPrint))) THEN
         CALL WriteIterationOutput(Iter,IThicknessIndex,IExitFLAG,IErr)
         IF(l_alert(IErr,"WriteIterationOutputWrapper","WriteIterationOutput")) RETURN
-        IPreviousPrintedIteration = Iter
       END IF
     END IF
 
@@ -75,9 +74,6 @@ MODULE write_output_mod
 
     USE MyNumbers
     USE message_mod
-    
-    ! global outputs
-    USE IPARA, ONLY : IPreviousPrintedIteration
     
     ! global inputs
     USE IPARA, ONLY : IPixelCount, ISimFLAG, IOutPutReflections, INoOfLacbedPatterns, &
@@ -116,7 +112,6 @@ MODULE write_output_mod
               Iter-IPreviousPrintedIteration)
       END IF
     END IF
-    ! NB WriteIterationOutput should only be called after Iter increment and SimulateAndFit
     
     ! Write Images to disk
     DO ind = 1,INoOfLacbedPatterns

--- a/src/felix/write_output_mod.f90
+++ b/src/felix/write_output_mod.f90
@@ -43,14 +43,17 @@ MODULE write_output_mod
   CONTAINS
 
   SUBROUTINE WriteIterationOutputWrapper(Iter,IThicknessIndex,IExitFLAG,IErr)
+
     USE MyNumbers
     USE message_mod
     USE MyMPI
-    ! global inputs
-    USE IPARA, ONLY : IPrint
-    INTEGER(IKIND), INTENT(IN) :: Iter,IThicknessIndex,IExitFLAG
-    INTEGER(IKIND), INTENT(OUT) :: IErr
-    INTEGER(IKIND) :: IPreviousPrintedIteration
+    ! global inputs/outputs
+    USE IPARA, ONLY : IPrint, IPreviousPrintedIteration
+
+    IMPLICIT NONE
+    INTEGER(IKIND),INTENT(IN) :: Iter,IThicknessIndex,IExitFLAG
+    INTEGER(IKIND),INTENT(OUT) :: IErr
+
     IF(my_rank.EQ.0) THEN
       ! use IPrint from felix.inp to specify how often to write Iteration output
       IF(IExitFLAG.EQ.1.OR.(Iter.GE.(IPreviousPrintedIteration+IPrint))) THEN
@@ -59,6 +62,7 @@ MODULE write_output_mod
         IPreviousPrintedIteration = Iter
       END IF
     END IF
+
   END SUBROUTINE
 
   !>


### PR DESCRIPTION
Simulation-only and simplex requires further testing to check their output but they are running without crashing.

Moved and improved the Write Iteration Output Wrapper from felixrefine.f90 to write_output_mod.f90 so that simplex.f90, MaxGradient and Parabolic refinement can all use it.

I have checked that the output matches for SrTiO3_short/ and GaAs_short/.